### PR TITLE
fix: hide original card during drag to prevent ghost artifacts

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useDraggable } from "@dnd-kit/core";
-import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,9 +29,10 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
     isDragging,
   } = useDraggable({ id: task.id });
 
+  // When dragging, hide the original card completely - DragOverlay handles the visual
   const style = {
-    transform: transform ? CSS.Transform.toString(transform) : undefined,
-    opacity: isDragging ? 0.5 : 1,
+    opacity: isDragging ? 0 : 1,
+    // Don't apply transform to original - causes ghost artifacts with DragOverlay
   };
 
   const priority = PRIORITIES.find((p) => p.value === task.priority);


### PR DESCRIPTION
When dragging a task card, the original was shown at 0.5 opacity with
transforms applied while DragOverlay also rendered a copy. This caused
visual glitches: ghost cards, floating badges, and text artifacts.

Fix: Set original card opacity to 0 during drag (DragOverlay handles
the visual feedback), and remove transform from original element.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual handling of dragged items to eliminate ghost artifacts and provide a cleaner drag-and-drop experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->