### PR TITLE
fix: project reorder persistence + remove distracting drag hint

### DIFF
--- a/src/components/ProjectSidebar.tsx
+++ b/src/components/ProjectSidebar.tsx
@@ -380,12 +380,6 @@ export function ProjectSidebar({ selectedProjectId, onSelectProject }: ProjectSi
         </div>
 
         <div className="flex-1 overflow-y-auto p-2">
-          {isDraggingTask && (
-            <div className="mb-2 px-2 py-1 text-xs text-blue-400 text-center">
-              Drop on a project to move task
-            </div>
-          )}
-          
           <DroppableNoProject
             isSelected={selectedProjectId === null}
             onSelect={() => onSelectProject(null)}


### PR DESCRIPTION
- Replace upsert with individual UPDATE calls for project reordering
  (upsert with partial data was failing silently)
- Remove 'Drop on a project to move task' hint text
  (visual highlight on hover is sufficient feedback)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the drag-and-drop instruction message that displayed when dragging tasks between projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->