### PR TITLE
fix: card reordering and column heights

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -73,7 +73,7 @@ export function Board({
 
   return (
     <>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 flex-1">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 flex-1 min-h-0">
         {COLUMNS.map((column) => (
           <DroppableColumn
             key={column.id}
@@ -119,12 +119,13 @@ function DroppableColumn({
   return (
     <div
       ref={setNodeRef}
-      className={`transition-all ${isOver ? "ring-2 ring-blue-500 ring-inset rounded-lg" : ""}`}
+      className={`h-full transition-all ${isOver ? "ring-2 ring-blue-500 ring-inset rounded-lg" : ""}`}
     >
       <Column
         id={id}
         title={title}
         tasks={tasks}
+        isOver={isOver}
         onEditTask={onEditTask}
         onDeleteTask={onDeleteTask}
         onToggleFlag={onToggleFlag}

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useDroppable } from "@dnd-kit/core";
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -12,14 +11,13 @@ interface ColumnProps {
   id: Status;
   title: string;
   tasks: Task[];
+  isOver?: boolean;
   onEditTask: (task: Task) => void;
   onDeleteTask: (taskId: string) => void;
   onToggleFlag: (taskId: string) => void;
 }
 
-export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFlag }: ColumnProps) {
-  const { setNodeRef, isOver } = useDroppable({ id });
-
+export function Column({ id, title, tasks, isOver, onEditTask, onDeleteTask, onToggleFlag }: ColumnProps) {
   const columnColors: Record<Status, string> = {
     BACKLOG: "border-zinc-600",
     IN_PROGRESS: "border-blue-600",
@@ -28,7 +26,7 @@ export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFla
 
   return (
     <div
-      className={`flex flex-col bg-zinc-950 rounded-lg border-t-4 ${columnColors[id]} min-h-[500px]`}
+      className={`flex flex-col bg-zinc-950 rounded-lg border-t-4 ${columnColors[id]} h-full`}
     >
       <div className="p-4 border-b border-zinc-800">
         <div className="flex items-center justify-between">
@@ -39,8 +37,7 @@ export function Column({ id, title, tasks, onEditTask, onDeleteTask, onToggleFla
         </div>
       </div>
       <div
-        ref={setNodeRef}
-        className={`flex-1 p-2 space-y-2 transition-colors ${
+        className={`flex-1 p-2 space-y-2 transition-colors overflow-y-auto ${
           isOver ? "bg-zinc-900/50" : ""
         }`}
       >

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useDraggable } from "@dnd-kit/core";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,13 +27,14 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
     listeners,
     setNodeRef,
     transform,
+    transition,
     isDragging,
-  } = useDraggable({ id: task.id });
+  } = useSortable({ id: task.id });
 
-  // When dragging, hide the original card completely - DragOverlay handles the visual
   const style = {
-    opacity: isDragging ? 0 : 1,
-    // Don't apply transform to original - causes ghost artifacts with DragOverlay
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
   };
 
   const priority = PRIORITIES.find((p) => p.value === task.priority);


### PR DESCRIPTION
## Summary
Fixes the two high-priority issues from UAT:

### Card Reordering (#22)
- **Root cause**: TaskCard used `useDraggable` instead of `useSortable` - sortable items need both drag AND drop capabilities for within-list sorting
- **Fix**: Switched to `useSortable` with proper transform/transition handling
- Also removed duplicate `useDroppable` from Column that was conflicting with Board's DroppableColumn wrapper
- Updated collision detection to prioritize task cards over columns for proper sorting behavior

### Column Heights (#23)
- **Root cause**: Columns used `min-h-[500px]` which doesn't stretch to fill available space
- **Fix**: Changed to `h-full` on columns and added `min-h-0` to grid container for proper flex behavior
- Added `overflow-y-auto` to column content for scrolling when many cards

## Testing
- [x] Build passes
- [ ] Verify card reordering works consistently within columns
- [ ] Verify columns extend to bottom of viewport
- [ ] Verify cross-column drag still works

Fixes #22, fixes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced drag-and-drop experience with improved collision detection for more accurate item placement across columns

* **Style**
  * Refined visual feedback when dragging items with adjusted opacity and enhanced hover state styling
  * Optimized column layout with improved scrolling behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->