### PR TITLE
feat: implement Ready tasks batch

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -54,6 +54,8 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
     onEdit(task);
   };
 
+  const isDone = task.status === "DONE";
+
   return (
     <Card
       ref={setNodeRef}
@@ -61,15 +63,15 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
       {...attributes}
       {...listeners}
       onClick={handleCardClick}
-      className={`cursor-grab active:cursor-grabbing bg-zinc-900 border-zinc-800 hover:border-zinc-700 transition-all hover:scale-[1.02] ${
-        task.needsReview ? "ring-2 ring-amber-500/50" : ""
-      }`}
+      className={`cursor-grab active:cursor-grabbing border-zinc-800 hover:border-zinc-700 transition-all hover:scale-[1.02] ${
+        isDone ? "bg-zinc-950 opacity-60" : "bg-zinc-900"
+      } ${task.needsReview ? "ring-2 ring-amber-500/50" : ""}`}
     >
       <CardContent className="p-2.5">
         {/* Top row: avatar, flag, menu */}
         <div className="flex items-center justify-between mb-1.5">
           <div className="flex items-center gap-1.5">
-            <span className="text-sm">{creator?.emoji}</span>
+            <span className={`text-sm ${isDone ? "opacity-50" : ""}`}>{creator?.emoji}</span>
             {task.needsReview && (
               <Flag className="h-3 w-3 text-amber-500 fill-amber-500" />
             )}
@@ -106,7 +108,9 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
         </div>
 
         {/* Title */}
-        <h3 className="font-medium text-sm leading-snug mb-1">{task.title}</h3>
+        <h3 className={`font-medium text-sm leading-snug mb-1 ${isDone ? "line-through text-zinc-500" : ""}`}>
+          {task.title}
+        </h3>
         
         {/* Details (if any) */}
         {task.description && (
@@ -115,13 +119,15 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
           </p>
         )}
         
-        {/* Priority badge */}
-        <Badge
-          variant="secondary"
-          className={`${priority?.color} text-white text-[10px] px-1.5 py-0 h-4`}
-        >
-          {priority?.label}
-        </Badge>
+        {/* Priority badge - only show if priority is set */}
+        {priority && (
+          <Badge
+            variant="secondary"
+            className={`${priority.color} ${isDone ? "opacity-50" : ""} text-white text-[10px] px-1.5 py-0 h-4`}
+          >
+            {priority.label}
+          </Badge>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -43,7 +43,7 @@ export async function updateTask(
     title: string;
     description: string | null;
     status: Status;
-    priority: Priority;
+    priority: Priority | null;
     creator: Creator;
     needsReview: boolean;
     position: number;

--- a/src/lib/api-store.ts
+++ b/src/lib/api-store.ts
@@ -113,7 +113,7 @@ export async function createTask(data: {
         title: data.title,
         description: data.description || null,
         status: "BACKLOG",
-        priority: data.priority || "MEDIUM",
+        priority: data.priority || null,
         creator: data.creator || "MOBY",
         needs_review: false,
         position: maxPos + 1,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,7 +17,7 @@ export interface Task {
   title: string;
   description: string | null;
   status: Status;
-  priority: Priority;
+  priority: Priority | null;
   creator: Creator;
   needsReview: boolean;
   position: number;


### PR DESCRIPTION
Implements 3 tasks from the Ready column:

## 1. Priority no longer defaults to Medium
- Made `priority` nullable in Task type
- API no longer defaults to MEDIUM
- Priority badge only shows when priority is set

## 2. Cmd/Ctrl+Enter to submit modals
- Added keyboard shortcut listener to TaskModal
- Works from any field in the modal

## 3. Done items visually de-emphasized
- 60% opacity on card
- Darker background (`bg-zinc-950`)
- Strikethrough on title
- Faded priority badge and creator emoji

---
Picked up from Ready column during this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Ctrl/Cmd+Enter) for quick task form submission.
  * Priority field is now optional and can be left unset.

* **Improvements**
  * Completed tasks now display with visual distinction: reduced opacity and strikethrough styling for better task status clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->