### PR TITLE
Fix drag-and-drop highlight and card hover glitch

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -5,6 +5,7 @@ import { useDroppable } from "@dnd-kit/core";
 import { Task, Status, COLUMNS } from "@/lib/types";
 import { Column } from "./Column";
 import { TaskModal } from "./TaskModal";
+import { useKanbanDnd } from "./KanbanDndContext";
 
 interface BoardProps {
   initialTasks: Task[];
@@ -114,7 +115,11 @@ function DroppableColumn({
   onDeleteTask: (taskId: string) => void;
   onToggleFlag: (taskId: string) => void;
 }) {
-  const { setNodeRef, isOver } = useDroppable({ id });
+  const { setNodeRef } = useDroppable({ id });
+  const { activeDropColumn, isDraggingTask } = useKanbanDnd();
+  
+  // Show highlight when this column is the active drop target
+  const isOver = isDraggingTask && activeDropColumn === id;
 
   return (
     <div

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -63,7 +63,7 @@ export function TaskCard({ task, onEdit, onDelete, onToggleFlag }: TaskCardProps
       {...attributes}
       {...listeners}
       onClick={handleCardClick}
-      className={`cursor-grab active:cursor-grabbing border-zinc-800 hover:border-zinc-700 transition-all hover:scale-[1.02] ${
+      className={`cursor-grab active:cursor-grabbing border-zinc-800 hover:border-zinc-700 transition-colors hover:bg-zinc-800 ${
         isDone ? "bg-zinc-950 opacity-60" : "bg-zinc-900"
       } ${task.needsReview ? "ring-2 ring-amber-500/50" : ""}`}
     >


### PR DESCRIPTION
## Summary
Fixes #34 - Inconsistent drag-and-drop highlight indicator
Fixes #35 - Card hover expansion padding visual glitch

## Changes
### Drag-and-Drop Highlight (#34)
- Added `activeDropColumn` state to `KanbanDndContext` that tracks which column the user is dragging over
- Updated `handleDragOver` to detect the target column whether hovering over the column itself or a task card within it
- `DroppableColumn` now uses the context state for reliable highlight rendering
- Blue indicator now appears consistently on ALL columns (Backlog, Ready, Done) regardless of whether they're empty or populated

### Card Hover Glitch (#35)
- Removed `hover:scale-[1.02]` transform that was causing padding/z-index visual artifacts
- Replaced with subtle `hover:bg-zinc-800` background color change
- Changed `transition-all` to `transition-colors` for cleaner animation

## Testing
1. Drag a card and verify blue ring appears on ALL columns when hovering
2. Verify indicator appears whether column is empty or has cards
3. Hover over cards and confirm no visual glitches (no padding overlap)

## Source
UAT video analysis (Feb 2, 2026)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced drag-and-drop interactions with improved visual feedback—columns now highlight more prominently to clearly indicate valid drop targets when dragging tasks across the kanban board
  * Updated task card hover effects to use background color changes instead of scaling animations, providing more consistent and intuitive visual feedback during user interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->